### PR TITLE
Fix: #2 breaks the ability to paste text in Firefox

### DIFF
--- a/assets/javascripts/image_paste.js
+++ b/assets/javascripts/image_paste.js
@@ -406,10 +406,11 @@ jQuery.event.props.push('dataTransfer');
         insertHtmlForTextarea: function(html) {
             if ( !this.selection ) return;
 
+            var inserted = false;
             try {
-              document.execCommand('insertText', false, html.replace(/\r\n/g, "\n"));
-              return;
+                inserted = document.execCommand('insertText', false, html.replace(/\r\n/g, "\n"));
             } catch (e) {}
+            if ( inserted ) return;
 
             this.selection.editor.value =
                 this.selection.editor.value.slice(0, this.selection.start)


### PR DESCRIPTION
I'm sorry, #2 doesn't work properly in Firefox as @shazada says.

`execCommand` returns `false` without throwing an exception, in Firefox.
I fixed the processing to be `return` only when `true` returns from execCommand.