### PR TITLE
Add support for Safari >= 8

### DIFF
--- a/assets/javascripts/image_paste.js
+++ b/assets/javascripts/image_paste.js
@@ -81,9 +81,10 @@ jQuery.event.props.push('dataTransfer');
                 M[1] = M[1].toLowerCase();
 
                 var isCompatChrome = (M[1] === 'webkit' && typeof window.chrome === "object" && browserMajor >= 535);
-                hasClipboard = isCompatChrome;
+                var isCompatSafari = (M[1] === 'webkit' && typeof window.safari === "object" && browserMajor >= 600);
 
                 if (isCompatChrome ||
+                    isCompatSafari ||
                     (M[1] === 'firefox' && browserMajor >= 3) ||
                     (M[1] === 'trident' && browserMajor >= 7))
                     return true;


### PR DESCRIPTION
Current version of plugin does not work very well on Safari. 
After first text insert the cursor will be frozen at this position.