### PR TITLE
Fix drag & drop for multiple files

### DIFF
--- a/assets/javascripts/image_paste.js
+++ b/assets/javascripts/image_paste.js
@@ -163,7 +163,6 @@ jQuery.event.props.push('dataTransfer');
 
                     e.preventDefault();
                     e.stopPropagation();
-                    break;
                 }
             });
         },


### PR DESCRIPTION
Using break command in for cycle will result in only uploading one file. 
I think that it was just oversight.