### PR TITLE
feat: support shift+insert paste

### DIFF
--- a/assets/javascripts/image_paste.js
+++ b/assets/javascripts/image_paste.js
@@ -118,10 +118,11 @@ jQuery.event.props.push('dataTransfer');
                 $("#paster").css('top', window.pageYOffset + 20).focus();
             }
 
-            var vKey = 86;
-
             $(document).keydown(function(e){
-                if ( (e.ctrlKey || e.metaKey) && !e.altKey && e.keyCode == vKey ) {
+                var isCtrlVCombination = (e.ctrlKey || e.metaKey) && !e.altKey && e.keyCode === 86;
+                var isShiftInsertCombination = e.shiftKey && e.keyCode === 45;
+
+                if (isCtrlVCombination || isShiftInsertCombination) {
                     if ( !self.isBrowserSupported() ) {
                         return;
                     }


### PR DESCRIPTION
**Problem**
Pasting with shift+insert on Chrome doesn't work properly because selection position is not updated.

**Steps to reproduce the problem**
Say we have this text on the text editor:
```
First line
Second line
Third line
```

If I copy "Third" word of third line and then paste it (ctrl+v or shift+insert) before "line" word of second line I got the following result, as expected:
```
First line
Second Thirdline
Third line
```

If now I paste it using shift+insert before "line" word of first line I got the following unexpected result:
```
First line
Second ThirdThirdline
Third line
```

Pasting occurs on the initial position because it never updates.

This was the expected result:
```
First Thirdline
Second Thirdline
Third line
```